### PR TITLE
Fix failing setter functions

### DIFF
--- a/JSONView.js
+++ b/JSONView.js
@@ -89,7 +89,9 @@ function JSONTreeView(name_, value_, parent_, isRoot_){
 				!!(readonly & 1) ? dom.container.classList.add('readonly')
 						: dom.container.classList.remove('readonly');
 				for (var i in children) {
-					children[i].readonly = setBit(readonly, 0, +ro);
+          if (typeof children[i] === 'object') {
+            children[i].readonly = setBit(readonly, 0, +ro);
+          }
 				}
 			}
 		},
@@ -164,7 +166,9 @@ function JSONTreeView(name_, value_, parent_, isRoot_){
 				}
 				alwaysShowRoot = value;
 				for (var i in children) {
-					children[i].alwaysShowRoot = value;
+          if (typeof children[i] === 'object') {
+            children[i].alwaysShowRoot = value;
+          }
 				}
 			}
 		},


### PR DESCRIPTION
I encountered a bug, where the setter functions would throw an exception, because the child element in question is a boolean instead of an object.